### PR TITLE
Use SerializableLock

### DIFF
--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -8,6 +8,7 @@ import pytest
 from packaging.version import parse
 
 from ..client import from_context
+from ..client.cache import Cache
 from ..client.context import Context
 
 MIN_VERSION = "0.1.0a104"
@@ -24,7 +25,7 @@ def test_pickle_context():
 
 
 @pytest.mark.parametrize("structure_clients", ["numpy", "dask"])
-def test_pickle_clients(structure_clients):
+def test_pickle_clients(structure_clients, tmpdir):
     try:
         httpx.get(API_URL).raise_for_status()
     except Exception:
@@ -34,7 +35,8 @@ def test_pickle_clients(structure_clients):
             raise pytest.skip(
                 f"Server at {API_URL} is running too old a version to test against."
             )
-        client = from_context(context, structure_clients)
+        cache = Cache(tmpdir / "http_response_cache.db")
+        client = from_context(context, structure_clients, cache)
         pickle.loads(pickle.dumps(client))
         for segements in [
             ["generated"],

--- a/tiled/_tests/test_pickle.py
+++ b/tiled/_tests/test_pickle.py
@@ -48,3 +48,10 @@ def test_pickle_clients(structure_clients, tmpdir):
                 original = original[segment]
             roundtripped = pickle.loads(pickle.dumps(original))
             assert roundtripped.uri == original.uri
+
+
+def test_lock_round_trip(tmpdir):
+    cache = Cache(tmpdir / "http_response_cache.db")
+    cache_round_tripped = pickle.loads(pickle.dumps(cache))
+    # implementation detail!
+    assert cache._lock.lock is cache_round_tripped._lock.lock


### PR DESCRIPTION
This PR fixes this problem:

```py
In [1]: from tiled.client.cache import Cache

In [2]: c = Cache()

In [3]: c._lock
Out[3]: <unlocked _thread.lock object at 0x7f1127ddf800>

In [4]: import pickle

In [5]: pickle.loads(pickle.dumps(c))
Out[5]: <Cache '/home/dallan/.cache/tiled/http_response_cache.db'>

In [6]: c2 = pickle.loads(pickle.dumps(c))

In [7]: c2._lock
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[7], line 1
----> 1 c2._lock

AttributeError: 'Cache' object has no attribute '_lock'
```

One solution would be to simple tack on a new lock in `__setstate__`:

```py
def __setstate__(self, state):
    ...
    self._lock = threading.Lock()
```

Using `SerializableLock` (which I stole shamelessly from `dask`) ensures that if a Tiled client is sent to another process (via pickling) and then sent _back_ the returned copy will share a lock with the original, rather than proliferate multiple unsynchronized locks.

To be clear, the lock is not shared _across_ processes. (Nor need it be.) But  within a given process, there is just one instance of a lock, and we verify that identity survives a round trip through pickle.